### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ before_script:
   - mkdir -p _build/$MIX_ENV
   - wget -O $PLT_LOCATION https://raw.github.com/jonnystorm/travis_elixir_plts/master/$PLT_FILENAME
 script:
-  - mix test
+  - mix test --include expensive
   - mix dialyzer --halt-exit-status

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,4 +31,4 @@ config :snmp_ex,
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :snmp_ex,
+  crypto_module: SNMP.Crypto

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :snmp_ex,
+  crypto_module: SNMP.Crypto

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :snmp_ex,
+  crypto_module: SNMP.FakeCrypto

--- a/dev_test.sh
+++ b/dev_test.sh
@@ -3,6 +3,6 @@
 while true; do
   inotifywait --exclude \..*\.sw. -re modify .
   clear
-    mix test --include integrated &&
+    mix test &&
     env MIX_ENV=test mix dialyzer --halt-exit-status
 done

--- a/lib/snmp/crypto.ex
+++ b/lib/snmp/crypto.ex
@@ -1,0 +1,65 @@
+defmodule SNMP.Crypto do
+  @moduledoc false
+
+  alias SNMP.Utility
+
+  defp convert_password_to_intermediate_key(password, algorithm)
+      when algorithm in [:md5, :sha]
+  do
+    data =
+      password
+      |> :binary.bin_to_list
+      |> Stream.cycle
+      |> Enum.take(1048576)
+
+    :crypto.hash(algorithm, data)
+  end
+
+  defp localize_key(key, algorithm, engine_id)
+      when algorithm in [:md5, :sha]
+  do
+    :crypto.hash(algorithm, "#{key}#{engine_id}#{key}")
+  end
+
+  @type password :: binary
+  @type algorithm :: :md5 | :sha
+  @type engine_id :: nil | binary
+
+  @spec convert_password_to_key(password, algorithm, engine_id) :: [byte]
+  def convert_password_to_key(password, algorithm, engine_id \\ nil)
+  def convert_password_to_key(password, algorithm, engine_id)
+      when algorithm in [:md5, :sha]
+  do
+    # Per RFC 3414, except use of localEngineID
+    eid = engine_id || Utility.get_local_engine_id()
+
+    password
+    |> convert_password_to_intermediate_key(algorithm)
+    |> localize_key(algorithm, eid)
+    |> :binary.bin_to_list
+  end
+
+end
+
+defmodule SNMP.FakeCrypto do
+  @moduledoc false
+
+  @type password :: binary
+  @type algorithm :: :md5 | :sha
+  @type engine_id :: nil | binary
+
+  @spec convert_password_to_key(password, algorithm, engine_id) :: [byte]
+  def convert_password_to_key(password, algorithm, engine_id \\ nil)
+
+  def convert_password_to_key("authpass", :md5, _),
+    do: [167, 81, 201, 199, 42, 46, 137, 43, 22, 203, 114, 40, 128, 16, 162, 141]
+
+  def convert_password_to_key("authpass", :sha, _),
+    do: [39, 237, 111, 41, 161, 2, 149, 234, 127, 88, 178, 4, 216, 251, 186, 158, 31, 164, 184, 199]
+
+  def convert_password_to_key("privpass", :md5, _),
+    do: [168, 5, 187, 57, 237, 205, 61, 51, 50, 34, 208, 202, 37, 247, 158, 92]
+
+  def convert_password_to_key("privpass", :sha, _),
+    do: [118, 114, 155, 192, 136, 56, 159, 175, 97, 219, 216, 18, 76, 140, 159, 2]
+end

--- a/lib/snmp/utility.ex
+++ b/lib/snmp/utility.ex
@@ -1,0 +1,6 @@
+defmodule SNMP.Utility do
+  @moduledoc false
+
+  @spec get_local_engine_id() :: <<_::40>>
+  def get_local_engine_id, do: <<0x8000000006::8*5>>
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"jds_math_ex": {:git, "https://github.com/jonnystorm/jds-math-elixir", "10d5cdf175b6a12b5ca9d97e4cb998e3324d6561", []},
+%{"earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc", "d294125a87b966ec221500af2a78e48626d81398", []},
+  "jds_math_ex": {:git, "https://github.com/jonnystorm/jds-math-elixir", "10d5cdf175b6a12b5ca9d97e4cb998e3324d6561", []},
   "linear_ex": {:git, "https://github.com/jonnystorm/linear-elixir", "a6a3dd8889d921878e8c01268fbad7714c599bd0", []},
-  "netaddr_ex": {:git, "https://github.com/jonnystorm/netaddr-elixir", "5afe3431fcdf8fcda5416fb1865d3888167ca251", []}}
+  "netaddr_ex": {:git, "https://github.com/jonnystorm/netaddr-elixir", "a88f81bfff2169c5c30ad46251a128a5d0c02447", []}}

--- a/test/snmp/crypto_test.exs
+++ b/test/snmp/crypto_test.exs
@@ -1,0 +1,23 @@
+defmodule SNMP.Crypto.Test do
+  use ExUnit.Case
+
+  import SNMP.Crypto
+
+  @moduletag :expensive
+
+  test "RFC 3414 A.3.1 - Password to Key Sample Results using MD5" do
+    password = "maplesyrup"
+    engine_id = <<0x000000000000000000000002::8*12>>
+    result = :binary.bin_to_list <<0x526f5eed9fcce26f8964c2930787d82b::8*16>>
+
+    assert convert_password_to_key(password, :md5, engine_id) == result
+  end
+
+  test "RFC 3414 A.3.2 - Password to Key Sample Results using SHA" do
+    password = "maplesyrup"
+    engine_id = <<0x000000000000000000000002::8*12>>
+    result = :binary.bin_to_list <<0x6695febc9288e36282235fc7151f128497b38f3f::8*20>>
+
+    assert convert_password_to_key(password, :sha, engine_id) == result
+  end
+end

--- a/test/snmp/mib_test.exs
+++ b/test/snmp/mib_test.exs
@@ -1,4 +1,4 @@
-defmodule SNMP.MIBTest do
+defmodule SNMP.MIB.Test do
   use ExUnit.Case
   doctest SNMP.MIB
 

--- a/test/snmp_test.exs
+++ b/test/snmp_test.exs
@@ -1,20 +1,4 @@
-defmodule SNMPTest do
+defmodule SNMP.Test do
   use ExUnit.Case
   doctest SNMP
-
-  test "RFC 3414 A.3.1 - Password to Key Sample Results using MD5" do
-    password = "maplesyrup"
-    engine_id = <<0x000000000000000000000002::8*12>>
-    result = :binary.bin_to_list <<0x526f5eed9fcce26f8964c2930787d82b::8*16>>
-
-    assert SNMP.convert_password_to_key(password, :md5, engine_id) == result
-  end
-
-  test "RFC 3414 A.3.2 - Password to Key Sample Results using SHA" do
-    password = "maplesyrup"
-    engine_id = <<0x000000000000000000000002::8*12>>
-    result = :binary.bin_to_list <<0x6695febc9288e36282235fc7151f128497b38f3f::8*20>>
-
-    assert SNMP.convert_password_to_key(password, :sha, engine_id) == result
-  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-ExUnit.configure exclude: [:integrated]
+ExUnit.configure exclude: [:expensive, :integrated]


### PR DESCRIPTION
* add doctests for
  - `SNMP.credential/1`
  - `SNMP.credential/2`
  - `SNMP.credential/3`
  - `SNMP.credential/5`
  - `SNMP.credential/7`
  - `SNMP.list_oid_to_string/1`
  - `SNMP.string_oid_to_list/1`
* move `SNMP.convert_password_to_key/3` to `SNMP.Crypto` module
* move `SNMP.get_local_engine_id/0` to `SNMP.Utility` module
* use `SNMP.FakeCrypto` while in test environment
* exclude `:expensive` and `:integrated` tests by default
* adjust `.travis.yml` to test `:expensive` tests in CI
* minor reformatting
* update dependencies