### PR TITLE
Clean up MIB compiler

### DIFF
--- a/lib/snmp/mib.ex
+++ b/lib/snmp/mib.ex
@@ -26,54 +26,62 @@ defmodule SNMP.MIB do
     |> Enum.to_list
   end
 
-  defp _get_imports_recursive([], _dir, acc),
-    do: Enum.uniq(acc)
+  defp _get_imports_recursive([], acc) do
+    acc
+    |> Enum.uniq
+    |> Enum.reverse
+  end
 
-  defp _get_imports_recursive([next_mib|rest], dir, acc) do
+  defp _get_imports_recursive([mib_file|rest], acc) do
     # This is a hack. Later, we may need to protect against loops with a
     # partial ordering structure.
-    mib_file = Path.join(dir, next_mib <> ".mib")
-
-    try do
-      rest
-      |> Enum.concat(
+    imports =
+      try do
         mib_file
         |> File.stream!
         |> get_imports_from_lines
         |> exclude_builtin_mibs
-      ) |> _get_imports_recursive(dir, [next_mib|acc])
+        |> Enum.map(&Path.join(Path.dirname(mib_file), "#{&1}.mib"))
 
-    rescue
-      File.Error ->
-        :ok = Logger.error("Unable to find MIB file: #{inspect mib_file}")
+      rescue
+        File.Error ->
+          :ok = Logger.error("Unable to find MIB file: #{inspect mib_file}")
 
-        _get_imports_recursive(rest, dir, acc)
+          []
+      end
+
+    if imports == [] do
+      _get_imports_recursive(rest, acc)
+    else
+      _get_imports_recursive(rest, Enum.concat([mib_file|imports], acc))
     end
   end
 
-  defp get_imports_recursive(mib_names, path) when is_list(mib_names),
-    do: _get_imports_recursive(mib_names, path, [])
+  defp get_imports_recursive(mib_files) when is_list(mib_files),
+    do: _get_imports_recursive(mib_files, [])
 
-  @type mib_path :: String.t
-  @type import_path :: String.t
+  @type mib_file :: String.t
+  @type include_paths :: [String.t]
 
-  @spec compile(mib_path, import_path) :: {:ok, term} | {:error, :term}
-  def compile(mib_path, import_path) do
-    erl_import_path = :binary.bin_to_list "#{import_path}/"
-    erl_mib_path = :binary.bin_to_list mib_path
+  @spec compile(mib_file, include_paths) :: {:ok, term} | {:error, term}
+  def compile(mib_file, include_paths) do
+    erl_mib_file = :binary.bin_to_list mib_file
+    erl_include_paths = Enum.map(include_paths, &:binary.bin_to_list("#{&1}/"))
+    outdir = :binary.bin_to_list Path.dirname(mib_file)
     options = [
+      warnings: false,
       #:warnings_as_errors,
-      i: [erl_import_path],
-      outdir: erl_import_path,
+      i: erl_include_paths,
+      outdir: outdir,
     ]
 
-    case :snmpc.compile(erl_mib_path, options) do
+    case :snmpc.compile(erl_mib_file, options) do
       {:error, {:invalid_file, _}} = error ->
-        :ok = Logger.error("Unable to compile invalid MIB file: #{inspect mib_path}")
+        :ok = Logger.error("Unable to compile invalid MIB file: #{inspect mib_file}")
 
         error
 
-      {:error, {:invalid_option, option}} = error -> 
+      {:error, {:invalid_option, option}} = error ->
         :ok = Logger.error("Unable to compile MIB with invalid option: #{inspect option}")
 
         error
@@ -83,19 +91,30 @@ defmodule SNMP.MIB do
     end
   end
 
+  defp list_files_with_mib_extension(paths) do
+    Enum.flat_map(paths, fn path ->
+      path
+      |> File.ls!
+      |> Stream.map(&Path.join(path, &1))
+      |> Enum.filter(&String.ends_with?(&1, ".mib"))
+    end)
+  end
+
+  @type mib_dir :: String.t
+
   @doc """
   Compile all .mib files in `mib_path`.
   """
-  @spec compile_all(mib_path) :: [{String.t, {:ok, term} | {:error, term}}]
-  def compile_all(mib_path) do
+  @spec compile_all([mib_dir]) :: [{mib_file, {:ok, term} | {:error, term}}]
+  def compile_all(mib_dirs) when is_list mib_dirs do
     # This doesn't handle subdirectories; may need to write find/2 later.
-    # This doesn't handle a separate list of import paths. Too hard right now.
-    mib_path
-    |> File.ls!
-    |> Stream.filter(&String.ends_with?(&1, ".mib"))
-    |> Enum.map(&Path.basename(&1, ".mib"))
-    |> get_imports_recursive(mib_path)
-    |> Enum.map(&Path.join(mib_path, "#{&1}.mib"))
-    |> Enum.map(&{&1, compile(&1, mib_path)})
+    mib_dirs
+    |> list_files_with_mib_extension
+    |> get_imports_recursive
+    |> Enum.map(&{&1, compile(&1, mib_dirs)})
   end
+
+  @spec compile_all(mib_dir) :: [{mib_file, {:ok, term} | {:error, term}}]
+  def compile_all(mib_dir),
+    do: compile_all([mib_dir])
 end

--- a/test/snmp/mib_test.exs
+++ b/test/snmp/mib_test.exs
@@ -19,7 +19,9 @@ defmodule SNMP.MIB.Test do
 
   test "Compiles directory of SNMP MIBs (with extension .mib) without errors" do
     results = compile_all @tmp_dir
+    mib_files = Enum.map(results, fn {f, _} -> :binary.bin_to_list(f) end)
 
-    assert Enum.all?(results, fn {_, {a, _}} -> a == :ok end)
+    assert Enum.all?(results, fn {_, {a, _}} -> a == :ok end) == true
+    assert :snmpc.is_consistent(mib_files) == :ok
   end
 end


### PR DESCRIPTION
* add support for compiling MIBs across multiple directories.
* make algorithm to retrieve imports simpler.
* improve names
* add consistency check to MIB compiler integrated test.