### PR TITLE
Clean-up and make experimentation easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore hidden and swap files
+.*
+*~
+
+# Ignore OTP SNMP files
+/manager.conf
+/snmpm_config_db

--- a/lib/snmp/crypto.ex
+++ b/lib/snmp/crypto.ex
@@ -31,7 +31,7 @@ defmodule SNMP.Crypto do
       when algorithm in [:md5, :sha]
   do
     # Per RFC 3414, except use of localEngineID
-    eid = engine_id || Utility.get_local_engine_id()
+    eid = engine_id || Utility.local_engine_id
 
     password
     |> convert_password_to_intermediate_key(algorithm)

--- a/lib/snmp/utility.ex
+++ b/lib/snmp/utility.ex
@@ -1,8 +1,8 @@
 defmodule SNMP.Utility do
   @moduledoc false
 
-  @spec get_local_engine_id() :: <<_::40>>
-  def get_local_engine_id, do: <<0x8000000006::8*5>>
+  @spec local_engine_id() :: <<_::40>>
+  def local_engine_id, do: <<0x8000000006::8*5>>
 
   # Takes
   #
@@ -60,8 +60,4 @@ defmodule SNMP.Utility do
     |> MapSet.new
     |> _partition_poset_as_antichains_of_minimal_elements(adjacency_map, [])
   end
-
-  @spec order_imports_by_dependency_chains(%{term => [term]}) :: [[term], ...]
-  def order_imports_by_dependency_chains(adjacency_map),
-    do: partition_poset_as_antichains_of_minimal_elements(adjacency_map)
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:git, "https://github.com/elixir-lang/ex_doc", "d294125a87b966ec221500af2a78e48626d81398", []},
   "jds_math_ex": {:git, "https://github.com/jonnystorm/jds-math-elixir", "10d5cdf175b6a12b5ca9d97e4cb998e3324d6561", []},
-  "linear_ex": {:git, "https://github.com/jonnystorm/linear-elixir", "a6a3dd8889d921878e8c01268fbad7714c599bd0", []},
-  "netaddr_ex": {:git, "https://github.com/jonnystorm/netaddr-elixir", "a88f81bfff2169c5c30ad46251a128a5d0c02447", []}}
+  "linear_ex": {:git, "https://github.com/jonnystorm/linear-elixir", "a755ad11bcd13ad0d54ddfdadfa00a73b1f2337f", []},
+  "netaddr_ex": {:git, "https://github.com/jonnystorm/netaddr-elixir", "e0ebd049d1b59d1bbdf4cd0cbcc8f3ccfcadf8a7", []}}


### PR DESCRIPTION
* break out Credential struct into specialized structs
* make `register_usm_user` and `register_agent` more homogeneous
* improve separation of concerns in `perform_snmp_op/5`
* make `:invalid_sec_info` errors clearer in `groom_snmp_result/1`
* move domain-specific naming out of `SNMP.Utility` into `SNMP.MIB`
* move related helper functions closer together
* some renaming, reformatting for clarity
* update dependencies