### PR TITLE
Finish object name resolution

### DIFF
--- a/lib/snmp/mib.ex
+++ b/lib/snmp/mib.ex
@@ -77,10 +77,9 @@ defmodule SNMP.MIB do
     erl_mib_file = :binary.bin_to_list mib_file
     erl_include_paths = Enum.map(include_paths, &:binary.bin_to_list("#{&1}/"))
     options = [
-      #:warnings_as_errors,
-      :relaxed_row_name_assign_check,
+      :relaxed_row_name_assign_check,  # added this on a lark; mistake?
       warnings: false,
-      group_check: false,
+      group_check: false,              # patched UCD-SNMP-MIB fails without this
       i: erl_include_paths,
       outdir: erl_outdir,
     ]
@@ -136,7 +135,6 @@ defmodule SNMP.MIB do
   """
   @spec compile_all([mib_dir]) :: [{mib_file, {:ok, term} | {:error, term}}]
   def compile_all(mib_dirs) when is_list mib_dirs do
-    # This doesn't handle subdirectories; may need to write find/2 later.
     mib_dirs
     |> list_files_with_mib_extension
     |> get_imports

--- a/lib/snmp/utility.ex
+++ b/lib/snmp/utility.ex
@@ -60,4 +60,58 @@ defmodule SNMP.Utility do
     |> MapSet.new
     |> _partition_poset_as_antichains_of_minimal_elements(adjacency_map, [])
   end
+
+  # Kludge to make snmp-elixir compile on 1.3.4 while avoiding
+  #   inevitable doom of `Enum.partition/2`
+  #
+  defmacrop separate_dirs_from_files(paths) do
+    if System.version =~ ~r/^1\.[0-3]\./ do
+      quote bind_quoted: [paths: paths] do
+        Enum.partition(paths, &File.lstat!(&1).type == :directory)
+      end
+    else
+      quote bind_quoted: [paths: paths] do
+        Enum.split_with(paths, &File.lstat!(&1).type == :directory)
+      end
+    end
+  end
+
+  defp _find_files_recursive([], _pattern, acc),
+    do: Enum.sort(acc)
+
+  defp _find_files_recursive([dir|rest], pattern, acc) do
+    {new_dirs, files} =
+      dir
+      |> File.ls!
+      |> Enum.map(&Path.absname(&1, dir))
+      |> separate_dirs_from_files
+
+    next_acc =
+      files
+      |> Enum.filter(&String.match?(&1, pattern))
+      |> Enum.concat(acc)
+
+    _find_files_recursive(new_dirs ++ rest, pattern, next_acc)
+  end
+
+  @type path :: String.t
+  @type pattern :: Regex.t
+  @type filepath :: String.t
+  @type filepaths :: [filepath, ...] | []
+
+  # Analogous to GNU find
+  @spec find_files_recursive(path, pattern) :: filepaths
+  def find_files_recursive(path, pattern \\ ~r//)
+
+  def find_files_recursive(path, pattern) do
+    if File.dir?(path) do
+      _find_files_recursive([path], pattern, [])
+    else
+      if String.match?(path, pattern) do
+        [path]
+      else
+        []
+      end
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,15 @@ defmodule SNMP.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger, :netaddr_ex]]
+    [ extra_applications: [
+        :logger,
+        :netaddr_ex
+      ],
+      env: [
+        mib_cache: "/tmp/snmp_ex/mibs",
+        mib_sources: ["/usr/share/snmp/mibs"],
+      ],
+    ]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
* Add environment variables `mib_cache`, `mib_sources`
* Fix/expand `resolve_object_name_to_oid/1` API
* Add automatic MIB compilation/loading to `SNMP.start`
* Add `Utility.find_files_recursive/2`
* Improve OID-related errors
* Remove `resolve_mib_name/1`