### PR TITLE
Use :snmp as application instead of :snmp_ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ iex> SNMP.walk("ipAddrTable", "an-snmp-host.local", v3_cred) |> Enum.take(1)
 
 ## Installation
 
-Add `:snmp_ex` to `mix.exs`:
+Add `:snmp` to `mix.exs`.
+For linux, make sure that `erlang-snmp` is installed on your machine.
 
 ```
 def application do
   [ extra_applications: [
       :logger,
-      :snmp_ex,
+      :snmp,
     ],
   ]
 end
@@ -77,6 +78,16 @@ config :snmp_ex,
   timeout: 5000,
   max_repetitions: 10
 ```
+
+You can ofcourse also overwrite the default storage directories:
+
+```
+config :snmp_ex,
+  mib_cache: "/data/snmp_ex/mibs",
+  snmp_conf_dir: "/data/snmp_ex/conf",
+  snmpm_conf_dir: "/data/snmp_ex"
+```
+
 
 ## Why another wrapper?
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,12 @@ use Mix.Config
 
 config :snmp_ex,
   timeout: 5000,
-  max_repetitions: 10
+  max_repetitions: 10,
+  mib_cache: "/tmp/snmp_ex/mibs",
+  snmp_conf_dir: "/tmp/snmp_ex/conf",
+  snmpm_conf_dir: "/tmp/snmp_ex",
+  mib_sources: ["/usr/share/snmp/mibs"],
+  engine_discovery_timeout: 1000
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/mix.exs
+++ b/mix.exs
@@ -2,11 +2,12 @@ defmodule SNMP.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :snmp_ex,
+    [
+      app: :snmp_ex,
       version: "0.1.2",
       elixir: "~> 1.7",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [
         plt_add_apps: [
@@ -14,16 +15,16 @@ defmodule SNMP.Mixfile do
           :snmp,
           :netaddr_ex,
           :jds_math_ex,
-          :linear_ex,
+          :linear_ex
         ],
         ignore_warnings: "dialyzer.ignore",
         flags: [
           :unmatched_returns,
           :error_handling,
           :race_conditions,
-          :underspecs,
-        ],
-      ],
+          :underspecs
+        ]
+      ]
     ]
   end
 
@@ -32,24 +33,18 @@ defmodule SNMP.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [ extra_applications: [
+    [
+      extra_applications: [
         :logger,
-        :netaddr_ex,
-      ],
-      env: [
-        mib_sources: ["/usr/share/snmp/mibs"],
-        mib_cache: "/tmp/snmp_ex/mibs",
-        snmp_conf_dir: "/tmp/snmp_ex/conf",
-        snmpm_conf_dir: "/tmp/snmp_ex",
-        engine_discovery_timeout: 1000,
-      ],
+        :netaddr_ex
+      ]
     ]
-    |> Keyword.merge(application(Mix.env))
+    |> Keyword.merge(application(Mix.env()))
   end
 
   def application(env)
       when env in [:test, :prod],
-    do: [mod: {SNMP, []}]
+      do: [mod: {SNMP, []}]
 
   def application(_),
     do: []
@@ -64,9 +59,9 @@ defmodule SNMP.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [ { :netaddr_ex,
-        git: "https://github.com/jonnystorm/netaddr-elixir"
-      },
+    [
+      {:netaddr_ex,
+       git: "https://github.com/jonnystorm/netaddr-elixir"}
     ]
   end
 end


### PR DESCRIPTION
using :snmp_ex is not necessary as it's already in the deps
Adding :snmp is necessary when distilling an application to run on a server

Add some extra info to readme
Change location of configuration