### PR TITLE
Fix #42: Refactor API to better support SNMPSET, credentials

### DIFF
--- a/dev_test.sh
+++ b/dev_test.sh
@@ -5,8 +5,8 @@ function run
   mix clean &&
     env MIX_ENV=test ERL_COMPILER_OPTIONS=bin_opt_info \
       mix compile --force &&
-    mix test --stale &&
-    env MIX_ENV=test mix dialyzer --halt-exit-status
+      mix test --stale &&
+      env MIX_ENV=test mix dialyzer --halt-exit-status
 }
 
 clear

--- a/lib/snmp/mib.ex
+++ b/lib/snmp/mib.ex
@@ -110,7 +110,7 @@ defmodule SNMP.MIB do
         Application.get_env(
           :snmp_ex,
           :snmpc_verbosity,
-          "silence"
+          :silence
         ),
       group_check: false,
       i: erl_include_paths,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule SNMP.Mixfile do
 
   def project do
     [ app: :snmp_ex,
-      version: "0.2.3",
+      version: "0.3.0",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "jds_math_ex": {:git, "https://gitlab.com/jonnystorm/jds-math-elixir.git", "e4090226e6d0139adac8ed310310e4e325da7bb5", []},
   "linear_ex": {:git, "https://gitlab.com/jonnystorm/linear-elixir.git", "b2bb2546f78e97e4fb6d6b2b3ad00f586864c312", []},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "netaddr_ex": {:hex, :netaddr_ex, "1.0.5", "996dbea308d1e2352b7fa92a2143a2d500546a2de71d8d59d3849b7f794dca0f", [:mix], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
* Introduce varbind abstraction
* Introduce `SNMP.request/2`
* Eliminate individual `get` and `set` functions
* Simplify, shrink credential interface
* Adjust credential struct field defaults
* Remove unused functions
* Fix minor bug in `SNMP.MIB.compile/2`
* Update tests