### PR TITLE
Make varbind result a map instead of tuple

### DIFF
--- a/lib/snmp.ex
+++ b/lib/snmp.ex
@@ -411,7 +411,10 @@ defmodule SNMP do
         varbinds
         |> Enum.sort_by(sort_fun)
         |> Enum.map(fn {_, oid, type, value, _} ->
-          {oid, type, value}
+          %{oid: oid,
+            type: type,
+            value: :binary.list_to_bin(value),
+          }
         end)
 
       {:error, {:invalid_oid, {:error, :not_found}}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule SNMP.Mixfile do
 
   def project do
     [ app: :snmp_ex,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Correct inconsistency between request varbinds and result varbinds.