### PR TITLE
Fix #48: Pass varbind type hints on SNMPSET

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ iex> %{uri: URI.parse("snmp://an-snmp-host.local"),
 ...>   credential: v2_cred,
 ...>   varbinds: [%{oid: base_oid ++ [0]}],
 ...> } |> SNMP.request
-[
-  %{oid: [1, 3, 6, 1, 2, 1, 1, 5, 0],
-    type: :"OCTET STRING",
-    value: "an-snmp-host"
-  }
-]
+{ :ok,
+  [ %{oid: [1, 3, 6, 1, 2, 1, 1, 5, 0],
+      type: :"OCTET STRING",
+      value: "an-snmp-host"
+    }
+  ]
+}
 iex>
 iex> v3_cred =
 ...>   SNMP.credential(
@@ -65,8 +66,7 @@ iex> v3_cred =
 }
 iex> SNMP.walk("ipAddrTable", "an-snmp-host.local", v3_cred)
 ...> |> Enum.take(1)
-[
-  %{oid: [1, 3, 6, 1, 2, 1, 4, 20, 1, 1, 192, 0, 2, 1],
+[ %{oid: [1, 3, 6, 1, 2, 1, 4, 20, 1, 1, 192, 0, 2, 1],
     type: :IpAddress,
     value: [192, 0, 2, 1],
   }

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule SNMP.Mixfile do
 
   def project do
     [ app: :snmp_ex,
-      version: "0.3.2",
+      version: "0.4.0",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
In cases where no corresponding MIB is present, an SNMPSET
without a type hint for the given value will fail.
Correctives given below.

* Pass varbind type hints on SNMPSET
* Handle unsuccessful, non-error replies from `:snmpm`
* Handle inconsistent/erroneous request varbinds
* Make `request/1` result structurally consistent
* Change `walk/3` to `walk/1`
* Fix typespecs
* Update README