### PR TITLE
Closes #53: CI integration tests with snmpsim docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,9 @@
 image: elixir:latest
 
+services:
+  - name: davaeron/snmpsim
+    alias: snmpsim
+
 variables:
   MIX_ENV: test
 
@@ -30,6 +34,6 @@ before_script:
 mix:
   script:
     - mix do deps.get, deps.compile
-    - mix test
+    - mix test --include integrated
     - mix dialyzer --halt-exit-status
 


### PR DESCRIPTION
I've made a docker image of snmpsim with needed parameters, made changes to .gitlab-ci.yml, made some changes to tests and now we can run tests in CI and localy with:
docker pull davaeron/snmpsim
docker run -d -p 161:161/udp davaeron/snmpsim

There is one problem though, officialy in Docker Hub where Gitlab CI gets elixir image, now we only have docker image of "elixir:latest" = "Elixir v1.10.4 (compiled with OTP 22.3.4.5)" and AES support requires OTP >= 23, so i've removed ":aes" from tests for now. As soon as we hit OTP 23, we can return it back.
'davaeron/snmpsim' docker image can use AES and has credentials to support SNMP v3 get/set tests. I've tested it with my local OTP 23.

My docker image source repo: https://github.com/davaeron/docker-snmpsim

CI works: https://gitlab.com/davaeron/snmp-elixir/-/pipelines/176327378