### PR TITLE
Fix SNMPv2 support

### DIFF
--- a/lib/snmp.ex
+++ b/lib/snmp.ex
@@ -956,7 +956,7 @@ defmodule SNMP do
         do: {:ok, oid}
     rescue
       e in ArgumentError ->
-        :ok = Logger.warn("Unhandled exception: did you forget to `SNMP.start`?")
+        :ok = Logger.warning("Unhandled exception: did you forget to `SNMP.start`?")
 
         reraise(e, __STACKTRACE__)
     end

--- a/lib/snmp.ex
+++ b/lib/snmp.ex
@@ -578,6 +578,7 @@ defmodule SNMP do
   end
 
   defp warmup_engine_boots_and_engine_time(
+    %{sec_model: :usm} = _credential,
     engine_id,
     target_name
   ) do
@@ -593,6 +594,12 @@ defmodule SNMP do
 
     :ok
   end
+
+  defp warmup_engine_boots_and_engine_time(
+    _credential,
+    _engine_id,
+    _target_name
+  ), do: :ok
 
   defp sha_sum(string) when is_binary(string),
     do: :crypto.hash(:sha, string)
@@ -699,9 +706,12 @@ defmodule SNMP do
       |> :binary.bin_to_list()
 
     discover_fun = fn ->
-      case discover_engine_id(uri, target) do
-        {:ok,  eid} -> :binary.list_to_bin(eid)
-        {:error, _} -> Utility.local_engine_id()
+      with %{sec_model: :usm} <- credential,
+           {:ok, eid} <- discover_engine_id(uri, target) do
+        :binary.list_to_bin(eid)
+      else
+        _error ->
+          Utility.local_engine_id()
       end
     end
 
@@ -721,6 +731,7 @@ defmodule SNMP do
            ),
          :ok <-
            warmup_engine_boots_and_engine_time(
+             credential,
              engine_id,
              target
            )

--- a/lib/snmp/mib.ex
+++ b/lib/snmp/mib.ex
@@ -123,7 +123,7 @@ defmodule SNMP.MIB do
       {rfc, link} =
         get_obsolete_mib_rfc_tuple(mib_name)
 
-      :ok = Logger.warn("Compiling obsolete MIB #{inspect(mib_name)}... This may not work. Please see #{rfc} at #{link} for details")
+      :ok = Logger.warning("Compiling obsolete MIB #{inspect(mib_name)}... This may not work. Please see #{rfc} at #{link} for details")
     end
 
     case :snmpc.compile(erl_mib_file, options) do


### PR DESCRIPTION
SNMPv2 device would not reply to discovery and warm-up requests leading to timeouts. Those are supported by SNMPv3 only anyway. Original request would take ~9 seconds due to this.
I've fixed some compiler warnings along the way.