### PR TITLE
Filter NULL as type and endOfMibView as value

### DIFF
--- a/lib/snmp.ex
+++ b/lib/snmp.ex
@@ -1114,6 +1114,10 @@ defp process_results(varbinds, base_oid) do
     List.starts_with?(oid, base_oid)
   end)
 
+  # Filter any results with NULL in the type field or endOfMibView in value
+  in_subtree = Enum.filter(in_subtree, fn %{type: type} -> type != :NULL end)
+  in_subtree = Enum.filter(in_subtree, fn %{value: value} -> value != :endOfMibView end)
+
   # FIXED: End reached if EITHER:
   # 1. There are no OIDs in our subtree
   # 2. There are ANY endOfMibView markers

--- a/test/snmp_test.exs
+++ b/test/snmp_test.exs
@@ -358,4 +358,20 @@ defmodule SNMP.Test do
       assert result == []
     end
   end
+
+  test "bulkwalk results filter endOfMibView and NULL for type from results" do
+    result = %{
+      uri: URI.parse("snmp://#{get_working_agent()}"),
+      credential: SNMP.credential(%{version: :v2, community: "public"}),
+      varbinds: [%{oid: [1, 3, 6, 1, 2, 1, 1]}]  # system subtree
+    }
+    |> SNMP.bulkwalk()
+    |> Enum.to_list()
+
+    assert length(result) > 0
+    # verify no result has NULL as the type
+    assert Enum.all?(result, fn %{type: type} -> type != :NULL end)
+    # verify no reuslt has endOfMibView as the value
+    assert Enum.all?(result, fn %{value: value} -> value != :endOfMibView end)
+  end
 end


### PR DESCRIPTION
Added separate filters for each in case of mangled packet results or similar.  NULL is the type returned for endOfMibView and endOfMibView is the value.